### PR TITLE
Previous groups order

### DIFF
--- a/app/components/PreviousGroupsPage.tsx
+++ b/app/components/PreviousGroupsPage.tsx
@@ -58,40 +58,48 @@ const PreviousGroupsPage = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {groups.map((group, index) => (
-                    <tr key={index} className="hover:bg-gray-100">
-                      <td
-                        className="px-1 py-0.5 border-y cursor-pointer"
-                        onClick={() => handleRowClick(index)}
-                      >
-                        {group.group_name}
-                      </td>
-                      <td className="px-1 py-0.5 border-y"
-                        onClick={() => handleRowClick(index)}>
-                        {group.expenses.length} gastos
-                      </td>
-                      <td className="px-1 py-0.5 border-y">
-                        <button
-                          className="text-blue-500 hover:underline mr-2"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleEditClick(index);
-                          }}
-                        >
-                          <AiOutlineEdit size={24} />
-                        </button>
-                        <button
-                          className="text-red-500 hover:underline"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleDeleteClick(index);
-                          }}
-                        >
-                          <AiOutlineDelete size={24} />
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
+                  {groups // All of this is to show the groups in reverse order but not change the original order
+                    .slice() 
+                    .reverse() 
+                    .map((group, reversedIndex) => {
+                      const originalIndex = groups.length - 1 - reversedIndex; // Calculate the original index
+                      return (
+                        <tr key={originalIndex} className="hover:bg-gray-100">
+                          <td
+                            className="px-1 py-0.5 border-y cursor-pointer"
+                            onClick={() => handleRowClick(originalIndex)}
+                          >
+                            {group.group_name}
+                          </td>
+                          <td
+                            className="px-1 py-0.5 border-y cursor-pointer"
+                            onClick={() => handleRowClick(originalIndex)}
+                          >
+                            {group.expenses.length} gastos
+                          </td>
+                          <td className="px-1 py-0.5 border-y">
+                            <button
+                              className="text-blue-500 hover:underline mr-2"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleEditClick(originalIndex);
+                              }}
+                            >
+                              <AiOutlineEdit size={24} />
+                            </button>
+                            <button
+                              className="text-red-500 hover:underline"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDeleteClick(originalIndex);
+                              }}
+                            >
+                              <AiOutlineDelete size={24} />
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
                 </tbody>
               </table>
             </div>

--- a/app/expenses/[group_id]/page.tsx
+++ b/app/expenses/[group_id]/page.tsx
@@ -17,7 +17,7 @@ const ExpensesDashboardPage = () => {
   const [groupData, setGroupData] = useState<Group | null>(null); 
   const router = useRouter();
   const params = useParams<{ group_id: string }>();
-  console.log(groupData);
+  //console.log(groupData);
 
   // Fetch group data after component mounts (client-side only)
   useEffect(() => {

--- a/app/lib/ResultsAlgorithm.tsx
+++ b/app/lib/ResultsAlgorithm.tsx
@@ -17,7 +17,7 @@ export default function calculateResults(expenses: Expense[]) {
 
     // Weird typescript rounding bug
     const share = Math.round((((amount / participants.length) + 0) * 100) / 100);
-    console.log(share)
+    //console.log(share)
     participants.forEach(participant => {
       if (participant !== payer) {
 
@@ -80,10 +80,10 @@ function simplifyDebts(debtMap: Record<string, Record<string, number>>) {
 
     const j = 0
     while (creditors[i].amount != 0) {
-      console.log("person: " + creditors[i].person + ", amount: " + creditors[i].amount)
+      //console.log("person: " + creditors[i].person + ", amount: " + creditors[i].amount)
 
       if (Math.abs(creditors[i].amount) >= Math.abs(debtors[j].amount)) {
-        console.log("case a: " + debtors[j].person + ", amount: " + debtors[j].amount)
+        //console.log("case a: " + debtors[j].person + ", amount: " + debtors[j].amount)
         // Send entire amount from debtor to creditor
         // All the debt is assigned to the same creditor and we remove the debtor from the list
 
@@ -129,7 +129,6 @@ function simplifyDebts(debtMap: Record<string, Record<string, number>>) {
 
 
 export function sortDebts(debtMap: DebtMap) {
-  //return debtMap
 
   const sortedDebts: DebtMap = Object.entries(debtMap)
     .map(([name, balances]) => {
@@ -142,6 +141,6 @@ export function sortDebts(debtMap: DebtMap) {
       return result;
     }, {} as DebtMap);
 
-  console.log(sortedDebts);
+  //console.log(sortedDebts);
   return sortedDebts
 }


### PR DESCRIPTION
When seeing the previous groups in the home page, we should see the most recent one at the top. This fixes #2 